### PR TITLE
Add missing inclusions of <stdlib.h>

### DIFF
--- a/src/pazpar2.c
+++ b/src/pazpar2.c
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <unistd.h>
 #endif
 
+#include <stdlib.h>
 #include <signal.h>
 #include <assert.h>
 

--- a/src/pazpar2_config.c
+++ b/src/pazpar2_config.c
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <config.h>
 #endif
 
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 

--- a/src/reclists.c
+++ b/src/reclists.c
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include <assert.h>
+#include <stdlib.h>
 
 #if HAVE_CONFIG_H
 #include <config.h>


### PR DESCRIPTION
Fixes the following errors seen with clang 18:

```
pazpar2.c:79:5: error: call to undeclared library function 'exit' with type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   79 |     exit(0);
      |     ^
pazpar2.c:79:5: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
```

```
pazpar2_config.c:586:44: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  586 |                 service->session_timeout = atoi((const char *) src);
      |                                            ^
pazpar2_config.c:597:52: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  597 |                 service->z3950_operation_timeout = atoi((const char *) src);
      |                                                    ^
pazpar2_config.c:608:50: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  608 |                 service->z3950_session_timeout = atoi((const char *) src);
      |                                                  ^
pazpar2_config.c:719:40: error: call to undeclared function 'atof'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  719 |                 service->rank_follow = atof(rank_follow);
      |                                        ^
pazpar2_config.c:723:38: error: call to undeclared function 'atof'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  723 |                 service->rank_lead = atof(rank_lead);
      |                                      ^
pazpar2_config.c:915:38: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  915 |                 server->proxy_port = atoi((const char *) port);
      |                                      ^
pazpar2_config.c:1252:38: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 1252 |                 config->no_threads = atoi((const char *) number);
      |                                      ^
pazpar2_config.c:1261:39: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 1261 |                 config->max_sockets = atoi((const char *) number);
      |                                       ^
```

```
reclists.c:318:5: error: call to undeclared function 'qsort'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  318 |     qsort(flatlist, l->num_records, sizeof(*flatlist), reclist_cmp);
      |     ^
```
