### PR TITLE
RPM: Fixes for systemd service file; reorder spec

### DIFF
--- a/rpm/pazpar2.service
+++ b/rpm/pazpar2.service
@@ -10,7 +10,6 @@ Type=simple
 EnvironmentFile=/etc/sysconfig/pazpar2
 Restart=on-abort
 KillMode=process
-PIDFile=${PP2_PID_FILE}
 ExecStart=/bin/bash -ce "exec /usr/sbin/pazpar2 ${PP2_OPTIONS}"
 
 [Install]

--- a/rpm/pazpar2.sysconfig
+++ b/rpm/pazpar2.sysconfig
@@ -1,4 +1,4 @@
 PP2_USER=nobody
-PP2_LOG=/var/log/pazpar2
-PP2_PID_FILE=/var/run/pazpar2.pid
-PP2_OPTIONS="-u ${PP2_USER} -l ${PP2_LOG} -f /etc/pazpar2/server.xml -p $PP2_PID_FILE"
+PP2_LOG=/var/log/pazpar2.log
+PP2_PID_FILE=/run/pazpar2.pid
+PP2_OPTIONS="-u ${PP2_USER} -l ${PP2_LOG} -p ${PP2_PID_FILE} -f /etc/pazpar2/server.xml"

--- a/rpm/pazpar2.sysconfig
+++ b/rpm/pazpar2.sysconfig
@@ -1,4 +1,3 @@
 PP2_USER=nobody
 PP2_LOG=/var/log/pazpar2.log
-PP2_PID_FILE=/run/pazpar2.pid
-PP2_OPTIONS="-u ${PP2_USER} -l ${PP2_LOG} -p ${PP2_PID_FILE} -f /etc/pazpar2/server.xml"
+PP2_OPTIONS="-u ${PP2_USER} -l ${PP2_LOG} -f /etc/pazpar2/server.xml"


### PR DESCRIPTION
Store systemd service in /usr/lib/systemd/system.
Use systemd-rpm-macros for dealing with systemd service in post, preun, postun.
Proper log file /var/log/pazpar2.log